### PR TITLE
Add one-digit submit key

### DIFF
--- a/doc/vertigo.txt
+++ b/doc/vertigo.txt
@@ -110,6 +110,14 @@ numbers) with a command like this in your .vimrc: >
     " 4 or smaller is 'small,' and 5 or larger is 'large'
     " You can also use 'smart2' or any other cutoff you want.
 
+If you would like a more manual approach but often forget to type zero or
+shift, you can set a key to submit the typed digit with a command like this in
+your .vimrc: >
+
+    let g:Vertigo_onedigit_key = ' '
+    " Triggering a jump prompt and typing 5<Space> jumps 5 lines
+    " You can set this to any key
+
 ==============================================================================
 4. Configuration                                              *vertigo-config*
 

--- a/plugin/vertigo.vim
+++ b/plugin/vertigo.vim
@@ -33,6 +33,12 @@ else
   let s:onedigit_method = g:Vertigo_onedigit_method
 endif
 
+if !exists('g:Vertigo_onedigit_key')
+  let s:onedigit_key = 'none'
+else
+  let s:onedigit_key = g:Vertigo_onedigit_key
+endif
+
 """"""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""""
 " General description of control flow:
 "
@@ -128,8 +134,8 @@ function! s:GetUserInput(promptstr)
 "                enters a digit, this will be something like 'Jump: 3'. (to
 "                simulate typing)
 "* EFFECTS:
-"    Prompts the user to jump. Only accepts input from the home row keys or ^C
-"    or <Esc> to cancel.
+"    Prompts the user to jump. Only accepts input from the home row keys, ^C
+"    or <Esc> to cancel, or the onedigit key to submit.
 "* RETURNS:
 "    A list describing the user's input, as follows.
 "    - [0] for canceling
@@ -144,6 +150,8 @@ function! s:GetUserInput(promptstr)
     let c = nr2char(getchar())
     if c == '' || c == ''
       return [0]
+    elseif c == s:onedigit_key
+      return [1, '']
     elseif has_key(s:keymap_onedigit, c)
       return [s:DigitType(1, s:keymap_onedigit[c]),
             \ s:keymap_onedigit[c]]


### PR DESCRIPTION
I added a setting for a key to submit a single typed digit, since I found it annoying when I would forget to press shift or type a zero before a one-digit jump.

Sorry to necro a somewhat old repo, it's a very useful tool.