### PR TITLE
docs: add item to related section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ Related
 -------
 
 - [Emacs port](https://github.com/noctuid/vertigo.el) by noctuid (I have not tried it)
+- [Ranger port](https://github.com/zachary-krepelka/ranger-vertigo)
 
 
 


### PR DESCRIPTION
Dear GitHub user @prendradjaja,

I have been using your plugin `vertigo.vim` for a few years now.  It has
become an integral part of my everyday workflow.  I couldn't imagine
running Vim without it.  Thank you for writing this amazing tool.

I am making this pull request to add an item to the related section of
the README file.  I ported your plugin to [ranger][1], a console file
manager with VI key bindings.  Vertical movement is a prominent aspect
of navigation in ranger.  As with Vim, ranger would benefit from your
user-interface reimagining.

Maybe I'm overstepping here, but I thought this would be the best way to
introduce my plugin to the community.  Please let me know what you
think.

Respectfully,
GitHub user @zachary-krepelka

[1]: https://wiki.archlinux.org/title/Ranger